### PR TITLE
Optimize spatial predicates when vectors are constant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 - [What is this?](#what-is-this)
 - [Example Usage](#example-usage)
 - [How do I get it?](#how-do-i-get-it)
-  - [Pre-built binaries](#pre-built-binaries)
+  - [Through the DuckDB CLI](#through-the-duckdb-cli)
+  - [Development builds](#development-builds)
   - [Building from source](#building-from-source)
 - [Limitations and Roadmap](#limitations-and-roadmap)
 - [Internals and technical details](#internals-and-technical-details)
@@ -348,6 +349,7 @@ Again, please feel free to open an issue if there is a particular function you w
 | ST_Centroid                 | 🧭        | 🦆        | 🦆            | 🦆         | 🦆              |
 | ST_Collect                  | 🦆        | 🦆        | 🦆            | 🦆         | 🦆              |
 | ST_Contains                 | 🧭        | 🔄        | 🔄            | 🦆 or 🔄   | 🔄 (as POLYGON) |
+| ST_ContainsProperly         | 🧭        | 🔄        | 🔄            | 🔄         | 🔄 (as POLYGON) |
 | ST_ConvexHull               | 🧭        | 🔄        | 🔄            | 🔄         | 🔄 (as POLYGON) |
 | ST_CoveredBy                | 🧭        | 🔄        | 🔄            | 🔄         | 🔄 (as POLYGON) |
 | ST_Covers                   | 🧭        | 🔄        | 🔄            | 🔄         | 🔄 (as POLYGON) |

--- a/spatial/include/spatial/geos/functions/scalar.hpp
+++ b/spatial/include/spatial/geos/functions/scalar.hpp
@@ -13,6 +13,7 @@ public:
 		RegisterStBuffer(context);
 		RegisterStCentroid(context);
 		RegisterStContains(context);
+		RegisterStContainsProperly(context);
 		RegisterStConvexHull(context);
 		RegisterStCoveredBy(context);
 		RegisterStCovers(context);
@@ -44,6 +45,7 @@ private:
 	static void RegisterStBuffer(ClientContext &context);
 	static void RegisterStCentroid(ClientContext &context);
 	static void RegisterStContains(ClientContext &context);
+	static void RegisterStContainsProperly(ClientContext &context);
 	static void RegisterStConvexHull(ClientContext &context);
 	static void RegisterStCoveredBy(ClientContext &context);
 	static void RegisterStCovers(ClientContext &context);

--- a/spatial/include/spatial/geos/geos_executor.hpp
+++ b/spatial/include/spatial/geos/geos_executor.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "spatial/common.hpp"
+#include "spatial/core/types.hpp"
+#include "spatial/geos/functions/scalar.hpp"
+#include "spatial/geos/functions/common.hpp"
+#include "spatial/geos/geos_wrappers.hpp"
+
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+
+namespace spatial {
+
+namespace geos {
+
+// Reflexive: Equals, Contains, Covers, CoveredBy, Intersects, Within
+// Anti-reflexive: Disjoint
+// Symmetric: Equals, Intersects, Crosses, Touches, Overlaps (and Disjoint? since Disjoint != Intersects)
+// Transitive: Equals, Contains, Covers, CoveredBy, Within
+
+// Optimize binary predicate helper which use prepared geometry when one of the arguments is a constant
+// This is much more common than you would think, e.g. joins produce a lot of constant vectors.
+typedef char (*GEOSBinaryPredicate)(GEOSContextHandle_t ctx, const GEOSGeometry *left, const GEOSGeometry *right);
+typedef char (*GEOSPreparedBinaryPredicate)(GEOSContextHandle_t ctx, const GEOSPreparedGeometry *left, const GEOSGeometry *right);
+
+struct GEOSExecutor {
+	// Symmetric: left and right can be swapped
+	// So we prepare either if one is constant
+	static void ExecuteSymmetricPreparedBinary(GEOSFunctionLocalState &lstate, Vector &left, Vector &right, idx_t count, Vector &result, 
+			GEOSBinaryPredicate normal, GEOSPreparedBinaryPredicate prepared) {
+		auto &ctx = lstate.ctx.GetCtx();
+
+		if(left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+			auto left_geom = lstate.factory.Deserialize(left_blob);
+			auto left_geos = lstate.ctx.FromGeometry(left_geom);
+			auto left_prepared_geos = left_geos.Prepare();
+
+			UnaryExecutor::Execute<string_t, bool>(right, result, count, [&](string_t &right_blob) {
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				auto ok = prepared(ctx, left_prepared_geos.get(), geos_right.get());
+				return ok == 1;
+			});
+		} else if(right.GetVectorType() == VectorType::CONSTANT_VECTOR && left.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			auto &right_blob = FlatVector::GetData<string_t>(right)[0];
+			auto right_geom = lstate.factory.Deserialize(right_blob);
+			auto right_geos = lstate.ctx.FromGeometry(right_geom);
+			auto right_prepared_geos = right_geos.Prepare();
+
+			UnaryExecutor::Execute<string_t, bool>(left, result, count, [&](string_t &left_blob) {
+				auto left_geometry = lstate.factory.Deserialize(left_blob);
+				auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+				auto ok = prepared(ctx, right_prepared_geos.get(), geos_left.get());
+				return ok == 1;
+			});
+		} else {
+			BinaryExecutor::Execute<string_t, string_t, bool>(left, right, result, count, [&](string_t &left_blob, string_t &right_blob) {
+				auto left_geometry = lstate.factory.Deserialize(left_blob);
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				auto ok = normal(ctx, geos_left.get(), geos_right.get());
+				return ok == 1;
+			});
+		}
+	}
+
+	// Non symmetric: left and right cannot be swapped
+	// So we only prepare left if left is constant
+	static void ExecuteNonSymmetricPreparedBinary(GEOSFunctionLocalState &lstate, Vector &left, Vector &right, idx_t count, Vector &result, 
+			GEOSBinaryPredicate normal, GEOSPreparedBinaryPredicate prepared) {
+		auto &ctx = lstate.ctx.GetCtx();
+
+		// Optimize: if one of the arguments is a constant, we can prepare it once and reuse it
+		if(left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+			auto left_geom = lstate.factory.Deserialize(left_blob);
+			auto left_geos = lstate.ctx.FromGeometry(left_geom);
+			auto left_prepared_geos = left_geos.Prepare();
+
+			UnaryExecutor::Execute<string_t, bool>(right, result, count, [&](string_t &right_blob) {
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				auto ok = prepared(ctx, left_prepared_geos.get(), geos_right.get());
+				return ok == 1;
+			});
+		} else {
+			BinaryExecutor::Execute<string_t, string_t, bool>(left, right, result, count, [&](string_t &left_blob, string_t &right_blob) {
+				auto left_geometry = lstate.factory.Deserialize(left_blob);
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				auto ok = normal(ctx, geos_left.get(), geos_right.get());
+				return ok == 1;
+			});
+		}
+	}
+};
+
+}
+
+}

--- a/spatial/include/spatial/geos/geos_wrappers.hpp
+++ b/spatial/include/spatial/geos/geos_wrappers.hpp
@@ -38,6 +38,14 @@ struct GeosDeleter<GEOSWKBReader_t> {
 	}
 };
 
+template <>
+struct GeosDeleter<const GEOSPreparedGeometry> {
+	GEOSContextHandle_t ctx;
+	void operator()(const GEOSPreparedGeometry *ptr) const {
+		GEOSPreparedGeom_destroy_r(ctx, ptr);
+	}
+};
+
 template <class T>
 unique_ptr<T, GeosDeleter<T>> make_unique_geos(GEOSContextHandle_t ctx, T *ptr) {
 	return unique_ptr<T, GeosDeleter<T>>(ptr, GeosDeleter<T> {ctx});
@@ -80,6 +88,10 @@ public:
 		return ptr;
 	}
 
+	unique_ptr<const GEOSPreparedGeometry, GeosDeleter<const GEOSPreparedGeometry>> Prepare() {
+		return make_unique_geos(ctx, GEOSPrepare_r(ctx, ptr));
+	}
+
 	// Accessors
 	double Area() const;
 	double Length() const;
@@ -106,16 +118,8 @@ public:
 	void Normalize() const;
 
 	// Predicates
-	bool Contains(const GeometryPtr &other) const;
-	bool Covers(const GeometryPtr &other) const;
-	bool CoveredBy(const GeometryPtr &other) const;
-	bool Crosses(const GeometryPtr &other) const;
-	bool Disjoint(const GeometryPtr &other) const;
 	bool Equals(const GeometryPtr &other) const;
-	bool Intersects(const GeometryPtr &other) const;
-	bool Overlaps(const GeometryPtr &other) const;
-	bool Touches(const GeometryPtr &other) const;
-	bool Within(const GeometryPtr &other) const;
+
 };
 
 struct WKBReader {
@@ -229,16 +233,14 @@ private:
 public:
 	GeosContextWrapper() {
 		ctx = GEOS_init_r();
-		// TODO: Set handlers
-		/*
-		GEOSContext_setNoticeHandler_r(ctx, NoticeHandler);
-		GEOSContext_setErrorHandler_r(ctx, ErrorHandler);
-		GEOSContext_setNoticeMessageHandler_r(ctx, ExceptionHandler, (void*)nullptr);
-		GEOSContext_setErrorMessageHandler_r(ctx, ExceptionHandler, (void*)nullptr);
-		 */
+		GEOSContext_setErrorMessageHandler_r(ctx, ErrorHandler, (void *)nullptr);
 	}
 	~GeosContextWrapper() {
 		GEOS_finish_r(ctx);
+	}
+
+	static void ErrorHandler(const char *message, void *userdata) {
+		throw InvalidInputException(message);
 	}
 
 	inline const GEOSContextHandle_t& GetCtx() {

--- a/spatial/src/spatial/geos/functions/scalar/CMakeLists.txt
+++ b/spatial/src/spatial/geos/functions/scalar/CMakeLists.txt
@@ -5,6 +5,7 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/st_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/st_centroid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/st_contains.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/st_containsproperly.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/st_convex_hull.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/st_covered_by.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/st_covers.cpp

--- a/spatial/src/spatial/geos/functions/scalar/st_contains.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_contains.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void ContainsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Contains(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteNonSymmetricPreparedBinary(lstate, left, right, count, result, GEOSContains_r, GEOSPreparedContains_r);
 }
 
 void GEOSScalarFunctions::RegisterStContains(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_containsproperly.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_containsproperly.cpp
@@ -1,0 +1,77 @@
+#include "spatial/common.hpp"
+#include "spatial/core/types.hpp"
+#include "spatial/geos/functions/scalar.hpp"
+#include "spatial/geos/functions/common.hpp"
+#include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
+
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/common/vector_operations/unary_executor.hpp"
+#include "duckdb/common/vector_operations/binary_executor.hpp"
+
+namespace spatial {
+
+namespace geos {
+
+using namespace spatial::core;
+
+static void ExecuteContainsProperlyPrepared(GEOSFunctionLocalState &lstate, Vector &left, Vector &right, idx_t count, Vector &result) {
+    auto &ctx = lstate.ctx.GetCtx();
+
+    if(left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+        auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+        auto left_geom = lstate.factory.Deserialize(left_blob);
+        auto left_geos = lstate.ctx.FromGeometry(left_geom);
+        auto left_prepared_geos = left_geos.Prepare();
+
+        UnaryExecutor::Execute<string_t, bool>(right, result, count, [&](string_t &right_blob) {
+            auto right_geometry = lstate.factory.Deserialize(right_blob);
+            auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+            auto ok = GEOSPreparedContainsProperly_r(ctx, left_prepared_geos.get(), geos_right.get());
+            return ok == 1;
+        });
+    } else {
+        // ContainsProperly only has a prepared version, so we just prepare the left one always
+        BinaryExecutor::Execute<string_t, string_t, bool>(left, right, result, count, [&](string_t &left_blob, string_t &right_blob) {
+            auto left_geometry = lstate.factory.Deserialize(left_blob);
+            auto right_geometry = lstate.factory.Deserialize(right_blob);
+            auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+            auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+            auto left_prepared = geos_left.Prepare();
+
+            auto ok = GEOSPreparedContainsProperly_r(ctx, left_prepared.get(), geos_right.get());
+            return ok == 1;
+        });
+    }
+}
+
+static void ContainsProperlyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+    ExecuteContainsProperlyPrepared(lstate, left, right, count, result);
+}
+
+void GEOSScalarFunctions::RegisterStContainsProperly(ClientContext &context) {
+	auto &catalog = Catalog::GetSystemCatalog(context);
+
+	ScalarFunctionSet set("ST_ContainsProperly");
+
+	set.AddFunction(ScalarFunction({GeoTypes::GEOMETRY(), GeoTypes::GEOMETRY()}, LogicalType::BOOLEAN, ContainsProperlyFunction, nullptr, nullptr, nullptr, GEOSFunctionLocalState::Init));
+
+	CreateScalarFunctionInfo info(std::move(set));
+	info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	catalog.CreateFunction(context, &info);
+}
+
+} // namespace spatials
+
+} // namespace spatial
+
+/*
+
+ST_Within(
+ST_GeomFromText('POLYGON((339 346, 459 346, 399 311, 340 277, 399 173, 280 242, 339 415, 280 381, 460 207, 339 346))'),
+ST_GeomFromText('POLYGON((339 207, 280 311, 460 138, 399 242, 459 277, 459 415, 399 381, 519 311, 520 242, 519 173, 399 450, 339 207))'));
+*/

--- a/spatial/src/spatial/geos/functions/scalar/st_covered_by.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_covered_by.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -16,14 +17,10 @@ using namespace spatial::core;
 
 static void CoveredByFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.CoveredBy(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteNonSymmetricPreparedBinary(lstate, left, right, count, result, GEOSCoveredBy_r, GEOSPreparedCoveredBy_r);
 }
 
 void GEOSScalarFunctions::RegisterStCoveredBy(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_covers.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_covers.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -15,15 +16,11 @@ namespace geos {
 using namespace spatial::core;
 
 static void CoversFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	auto &local_state = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = local_state.factory.Deserialize(left_blob);
-		auto right_geometry = local_state.factory.Deserialize(right_blob);
-		auto geos_left = local_state.ctx.FromGeometry(left_geometry);
-		auto geos_right = local_state.ctx.FromGeometry(right_geometry);
-		return geos_left.Covers(geos_right);
-	});
+	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteNonSymmetricPreparedBinary(lstate, left, right, count, result, GEOSCovers_r, GEOSPreparedCovers_r);
 }
 
 void GEOSScalarFunctions::RegisterStCovers(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_crosses.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_crosses.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void CrossesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Crosses(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteSymmetricPreparedBinary(lstate, left, right, count, result, GEOSCrosses_r, GEOSPreparedCrosses_r);
 }
 
 void GEOSScalarFunctions::RegisterStCrosses(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_disjoint.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_disjoint.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void DisjointFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Disjoint(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteSymmetricPreparedBinary(lstate, left, right, count, result, GEOSDisjoint_r, GEOSPreparedDisjoint_r);
 }
 
 void GEOSScalarFunctions::RegisterStDisjoint(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_distance.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_distance.cpp
@@ -15,21 +15,55 @@ namespace geos {
 
 using namespace spatial::core;
 
+static void ExecutePreparedDistance(GEOSFunctionLocalState &lstate, Vector &left, Vector &right, idx_t count, Vector &result) {
+		auto &ctx = lstate.ctx.GetCtx();
+
+		// Optimize: if one of the arguments is a constant, we can prepare it once and reuse it
+		if(left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+			auto left_geom = lstate.factory.Deserialize(left_blob);
+			auto left_geos = lstate.ctx.FromGeometry(left_geom);
+			auto left_prepared_geos = left_geos.Prepare();
+
+			UnaryExecutor::Execute<string_t, double>(right, result, count, [&](string_t &right_blob) {
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				double distance;
+				auto ok = GEOSPreparedDistance_r(ctx, left_prepared_geos.get(), geos_right.get(), &distance);
+				return ok == 1;
+			});
+		} else if(right.GetVectorType() == VectorType::CONSTANT_VECTOR && left.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			auto &right_blob = FlatVector::GetData<string_t>(right)[0];
+			auto right_geom = lstate.factory.Deserialize(right_blob);
+			auto right_geos = lstate.ctx.FromGeometry(right_geom);
+			auto right_prepared_geos = right_geos.Prepare();
+
+			UnaryExecutor::Execute<string_t, double>(left, result, count, [&](string_t &left_blob) {
+				auto left_geometry = lstate.factory.Deserialize(left_blob);
+				auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+				double distance;
+				auto ok = GEOSPreparedDistance_r(ctx, right_prepared_geos.get(), geos_left.get(), &distance);
+				return ok == 1;
+			});
+		} else {
+			BinaryExecutor::Execute<string_t, string_t, double>(left, right, result, count, [&](string_t &left_blob, string_t &right_blob) {
+				auto left_geometry = lstate.factory.Deserialize(left_blob);
+				auto right_geometry = lstate.factory.Deserialize(right_blob);
+				auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+				auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+				double distance;
+				auto ok = GEOSDistance_r(ctx, geos_left.get(), geos_right.get(), &distance);
+				return ok == 1;
+			});
+		}
+	}
+
 static void DistanceFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, double>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		double distance;
-		auto ok = GEOSDistance_r(lstate.ctx.GetCtx(), geos_left.get(), geos_right.get(), &distance);
-		if (!ok) {
-			throw Exception("GEOSDistance_r failed");
-		}
-		return distance;
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	ExecutePreparedDistance(lstate, left, right, count, result);
 }
 
 void GEOSScalarFunctions::RegisterStDistance(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_distance_within.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_distance_within.cpp
@@ -15,18 +15,54 @@ namespace geos {
 
 using namespace spatial::core;
 
+static void ExecutePreparedDistanceWithin(GEOSFunctionLocalState &lstate, Vector &left, Vector &right, Vector &distance_vec, idx_t count, Vector &result) {
+	auto &ctx = lstate.ctx.GetCtx();
+
+	// Optimize: if one of the arguments is a constant, we can prepare it once and reuse it
+	if(left.GetVectorType() == VectorType::CONSTANT_VECTOR && right.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		auto &left_blob = FlatVector::GetData<string_t>(left)[0];
+		auto left_geom = lstate.factory.Deserialize(left_blob);
+		auto left_geos = lstate.ctx.FromGeometry(left_geom);
+		auto left_prepared_geos = left_geos.Prepare();
+
+		BinaryExecutor::Execute<string_t, double, bool>(right, distance_vec, result, count, [&](string_t &right_blob, double distance) {
+			auto right_geometry = lstate.factory.Deserialize(right_blob);
+			auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+			auto ok = GEOSPreparedDistanceWithin_r(ctx, left_prepared_geos.get(), geos_right.get(), distance);
+			return ok == 1;
+		});
+	} else if(right.GetVectorType() == VectorType::CONSTANT_VECTOR && left.GetVectorType() != VectorType::CONSTANT_VECTOR) {
+		auto &right_blob = FlatVector::GetData<string_t>(right)[0];
+		auto right_geom = lstate.factory.Deserialize(right_blob);
+		auto right_geos = lstate.ctx.FromGeometry(right_geom);
+		auto right_prepared_geos = right_geos.Prepare();
+
+		BinaryExecutor::Execute<string_t, double, bool>(left, distance_vec, result, count, [&](string_t &left_blob, double distance) {
+			auto left_geometry = lstate.factory.Deserialize(left_blob);
+			auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+			auto ok = GEOSPreparedDistanceWithin_r(ctx, right_prepared_geos.get(), geos_left.get(), distance);
+			return ok == 1;
+		});
+	} else {
+		TernaryExecutor::Execute<string_t, string_t, double, bool>(left, right, distance_vec, result, count, [&](string_t &left_blob, string_t &right_blob, double distance) {
+			auto left_geometry = lstate.factory.Deserialize(left_blob);
+			auto right_geometry = lstate.factory.Deserialize(right_blob);
+			auto geos_left = lstate.ctx.FromGeometry(left_geometry);
+			auto geos_right = lstate.ctx.FromGeometry(right_geometry);
+			auto ok = GEOSDistanceWithin_r(ctx, geos_left.get(), geos_right.get(), distance);
+			return ok == 1;
+		});
+	}
+}
+
 static void DistanceWithinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto &distance_vec = args.data[2];
+	auto count = args.size();
+	ExecutePreparedDistanceWithin(lstate, left, right, distance_vec, count, result);
 
-	TernaryExecutor::Execute<string_t, string_t, double, bool>(args.data[0], args.data[1], args.data[2], result, args.size(),
-	                                                           [&](string_t &left_blob, string_t &right_blob, double distance) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		auto ok = 1 == GEOSDistanceWithin_r(lstate.ctx.GetCtx(), geos_left.get(), geos_right.get(), distance);
-		return ok;
-	});
 }
 
 void GEOSScalarFunctions::RegisterStDistanceWithin(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_intersects.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_intersects.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void IntersectsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Intersects(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteSymmetricPreparedBinary(lstate, left, right, count, result, GEOSIntersects_r, GEOSPreparedIntersects_r);
 }
 
 void GEOSScalarFunctions::RegisterStIntersects(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_overlaps.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_overlaps.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void OverlapsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Overlaps(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteSymmetricPreparedBinary(lstate, left, right, count, result, GEOSOverlaps_r, GEOSPreparedOverlaps_r);
 }
 
 void GEOSScalarFunctions::RegisterStOverlaps(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_touches.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_touches.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void TouchesFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Touches(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteSymmetricPreparedBinary(lstate, left, right, count, result, GEOSTouches_r, GEOSPreparedTouches_r);
 }
 
 void GEOSScalarFunctions::RegisterStTouches(ClientContext &context) {

--- a/spatial/src/spatial/geos/functions/scalar/st_within.cpp
+++ b/spatial/src/spatial/geos/functions/scalar/st_within.cpp
@@ -3,6 +3,7 @@
 #include "spatial/geos/functions/scalar.hpp"
 #include "spatial/geos/functions/common.hpp"
 #include "spatial/geos/geos_wrappers.hpp"
+#include "spatial/geos/geos_executor.hpp"
 
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/common/vector_operations/unary_executor.hpp"
@@ -17,14 +18,10 @@ using namespace spatial::core;
 
 static void WithinFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &lstate = GEOSFunctionLocalState::ResetAndGet(state);
-
-	BinaryExecutor::Execute<string_t, string_t, bool>(args.data[0], args.data[1], result, args.size(), [&](string_t &left_blob, string_t &right_blob) {
-		auto left_geometry = lstate.factory.Deserialize(left_blob);
-		auto right_geometry = lstate.factory.Deserialize(right_blob);
-		auto geos_left = lstate.ctx.FromGeometry(left_geometry);
-		auto geos_right = lstate.ctx.FromGeometry(right_geometry);
-		return geos_left.Within(geos_right);
-	});
+	auto &left = args.data[0];
+	auto &right = args.data[1];
+	auto count = args.size();
+	GEOSExecutor::ExecuteNonSymmetricPreparedBinary(lstate, left, right, count, result, GEOSWithin_r, GEOSPreparedWithin_r);
 }
 
 void GEOSScalarFunctions::RegisterStWithin(ClientContext &context) {

--- a/spatial/src/spatial/geos/geos_wrappers.cpp
+++ b/spatial/src/spatial/geos/geos_wrappers.cpp
@@ -135,44 +135,8 @@ void GeometryPtr::Normalize() const {
 }
 
 // Predicates
-bool GeometryPtr::Covers(const GeometryPtr &other) const {
-	return GEOSCovers_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::CoveredBy(const spatial::geos::GeometryPtr &other) const {
-	return GEOSCoveredBy_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Crosses(const GeometryPtr &other) const {
-	return GEOSCrosses_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Disjoint(const GeometryPtr &other) const {
-	return GEOSDisjoint_r(ctx, ptr, other.ptr);
-}
-
 bool GeometryPtr::Equals(const GeometryPtr &other) const {
 	return GEOSEquals_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Intersects(const GeometryPtr &other) const {
-	return GEOSIntersects_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Overlaps(const GeometryPtr &other) const {
-	return GEOSOverlaps_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Touches(const GeometryPtr &other) const {
-	return GEOSTouches_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Within(const GeometryPtr &other) const {
-	return GEOSWithin_r(ctx, ptr, other.ptr);
-}
-
-bool GeometryPtr::Contains(const GeometryPtr &other) const {
-	return GEOSContains_r(ctx, ptr, other.ptr);
 }
 
 


### PR DESCRIPTION
### Misc
- We now properly throw exceptions on GEOS errors.

### Functions & Casts
- Added `ST_ContainsProperly`

### Optimizations
We now create GEOS "prepared geometries" when executing spatial predicates when we know that one of the arguments is a DuckDB ConstantVector. We also optimize `ST_Distance` and `ST_DistanceWithin`. Being able to do this optimization is a really cool way to leverage how DuckDB's vectorized execution engine works.

Originally I thought that this would only be a performance win in the case when you want to apply a filter with a specific constant geometry, like in `SELECT geom WHERE ST_Intersects(geom, ST_GeomFromText('...')) FROM tbl` but it turns out that we also produce ConstantVectors when e.g. doing joins, which gave spatial joins a surprisingly big boost. We still don't have any general spatial indexes though so It's still not fast enough to join all 1000000 rides with all 264 zones in our taxi dataset in real-time, but here's a micro benchmark.

Setup:
```sql
load parquet;
CREATE TABLE rides AS SELECT * FROM 'spatial/test/data/nyc_taxi/yellow_tripdata_2010-01-limit1mil.parquet';
CREATE TABLE zones AS SELECT * FROM st_read('./spatial/test/data/nyc_taxi/taxi_zones/');
PRAGMA enable_profiling;
```

Running this query:
```sql
 SELECT rides.pickup_latitude, rides.pickup_longitude, z.zone FROM (SELECT * FROM zones LIMIT 1) as z JOIN rides ON ST_Contains(st_geomfromwkb(z.wkb_geometry), ST_Transform(st_point(pickup_latitude, pickup_longitude), 'EPSG:4326', 'ESRI:102718'));
 ```
 As we increase the number of zones, 'n' in `... LIMIT n) as z`:
 | n | before | after |
 |--|-------|-------|
 |1 |  2.43s   | 1.46s |
 |2|  25.56s  | 2.95s |
 |3| 28.26s   | 4.40s |
 |10| 43.83s  | 14.26s |
 |20| 68.27 | 28.56 |
 
 ![chart](https://user-images.githubusercontent.com/1337636/235321042-983db782-5f82-4bd0-9a96-d555bd933b1d.png)
 