### PR TITLE
Add blob overload for `ST_GeomFromWKB`, throw exception on out of bounds

### DIFF
--- a/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
@@ -288,8 +288,8 @@ void CoreScalarFunctions::RegisterStGeomFromWKB(ClientContext &context) {
 	catalog.CreateFunction(context, &polygon2d_from_wkb_info);
 
 	ScalarFunctionSet st_geom_from_wkb("ST_GeomFromWKB");
-	st_geom_from_wkb.AddFunction(ScalarFunction("ST_GeomFromWKB", {GeoTypes::WKB_BLOB()}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
-	st_geom_from_wkb.AddFunction(ScalarFunction("ST_GeomFromWKB", {LogicalType::BLOB}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
+	st_geom_from_wkb.AddFunction(ScalarFunction({GeoTypes::WKB_BLOB()}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
+	st_geom_from_wkb.AddFunction(ScalarFunction({LogicalType::BLOB}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
 	CreateScalarFunctionInfo geometry_from_wkb_info(st_geom_from_wkb);
 	catalog.CreateFunction(context, &geometry_from_wkb_info);
 }

--- a/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_geomfromwkb.cpp
@@ -287,8 +287,10 @@ void CoreScalarFunctions::RegisterStGeomFromWKB(ClientContext &context) {
 	    ScalarFunction("ST_Polygon2DFromWKB", {GeoTypes::WKB_BLOB()}, GeoTypes::POLYGON_2D(), Polygon2DFromWKBFunction));
 	catalog.CreateFunction(context, &polygon2d_from_wkb_info);
 
-	CreateScalarFunctionInfo geometry_from_wkb_info(
-	    ScalarFunction("ST_GeomFromWKB", {GeoTypes::WKB_BLOB()}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
+	ScalarFunctionSet st_geom_from_wkb("ST_GeomFromWKB");
+	st_geom_from_wkb.AddFunction(ScalarFunction("ST_GeomFromWKB", {GeoTypes::WKB_BLOB()}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
+	st_geom_from_wkb.AddFunction(ScalarFunction("ST_GeomFromWKB", {LogicalType::BLOB}, GeoTypes::GEOMETRY(), GeometryFromWKBFunction, nullptr, nullptr, nullptr, GeometryFunctionLocalState::Init));
+	CreateScalarFunctionInfo geometry_from_wkb_info(st_geom_from_wkb);
 	catalog.CreateFunction(context, &geometry_from_wkb_info);
 }
 

--- a/spatial/src/spatial/core/geometry/wkb_reader.cpp
+++ b/spatial/src/spatial/core/geometry/wkb_reader.cpp
@@ -10,7 +10,9 @@ namespace core {
 
 template <>
 uint32_t WKBReader::ReadInt<WKBByteOrder::NDR>() {
-	D_ASSERT(cursor + sizeof(uint32_t) <= length);
+	if(cursor + sizeof(uint32_t) > length) {
+		throw SerializationException("WKBReader: ReadInt: not enough data");
+	}
 	// Read uint32_t in little endian
 	uint32_t result = 0;
 	result |= (uint32_t)data[cursor + 0] << 0 & 0x000000FF;
@@ -23,7 +25,9 @@ uint32_t WKBReader::ReadInt<WKBByteOrder::NDR>() {
 
 template <>
 double WKBReader::ReadDouble<WKBByteOrder::NDR>() {
-	D_ASSERT(cursor + sizeof(double) <= length);
+	if (cursor + sizeof(double) > length) {
+		throw SerializationException("WKBReader: ReadDouble: not enough data");
+	}
 	// Read double in little endian
 	uint64_t result = 0;
 	result |= (uint64_t)data[cursor + 0] << 0 & 0x00000000000000FF;
@@ -40,7 +44,9 @@ double WKBReader::ReadDouble<WKBByteOrder::NDR>() {
 
 template <>
 uint32_t WKBReader::ReadInt<WKBByteOrder::XDR>() {
-	D_ASSERT(cursor + sizeof(uint32_t) <= length);
+	if(cursor + sizeof(uint32_t) > length) {
+		throw SerializationException("WKBReader: ReadInt: not enough data");
+	}
 	// Read uint32_t in big endian
 	uint32_t result = 0;
 	result |= (uint32_t)data[cursor + 0] << 24 & 0xFF000000;
@@ -53,7 +59,9 @@ uint32_t WKBReader::ReadInt<WKBByteOrder::XDR>() {
 
 template <>
 double WKBReader::ReadDouble<WKBByteOrder::XDR>() {
-	D_ASSERT(cursor + sizeof(double) <= length);
+	if(cursor + sizeof(double) > length) {
+		throw SerializationException("WKBReader: ReadDouble: not enough data");
+	}
 	// Read double in big endian
 	uint64_t result = 0;
 	result |= (uint64_t)data[cursor + 0] << 56 & 0xFF00000000000000;
@@ -187,7 +195,7 @@ Geometry WKBReader::ReadGeometryImpl() {
 	case WKBGeometryType::GEOMETRYCOLLECTION:
 		return Geometry(ReadGeometryCollectionImpl<ORDER>());
 	default:
-		throw NotImplementedException("Geometry type not implemented");
+		throw NotImplementedException("Geometry type not supported");
 	}
 }
 

--- a/spatial/test/sql/geometry/st_geomfromwkb.test
+++ b/spatial/test/sql/geometry/st_geomfromwkb.test
@@ -1,0 +1,60 @@
+# Test wkb blob roundtrip for geometry types
+require spatial
+
+statement ok
+CREATE TABLE types (geom GEOMETRY);
+
+statement ok
+INSERT INTO types VALUES
+    (ST_GeomFromText('POINT EMPTY')),
+    (ST_GeomFromText('POINT(0 0)')),
+    (ST_GeomFromText('LINESTRING EMPTY')),
+    (ST_GeomFromText('LINESTRING(0 0, 1 1)')),
+    (ST_GeomFromText('POLYGON EMPTY')),
+    (ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')),
+    (ST_GeomFromText('MULTIPOINT EMPTY')),
+    (ST_GeomFromText('MULTIPOINT(0 0, 1 1)')),
+    (ST_GeomFromText('MULTILINESTRING EMPTY')),
+    (ST_GeomFromText('MULTILINESTRING((0 0, 1 1), (2 2, 3 3))')),
+    (ST_GeomFromText('MULTIPOLYGON EMPTY')),
+    (ST_GeomFromText('MULTIPOLYGON(((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))')),
+    (ST_GeomFromText('GEOMETRYCOLLECTION EMPTY')),
+    (ST_GeomFromText('GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 1))'));
+
+# Convert to WKB_BLOB and back
+query I
+SELECT ST_AsText(ST_GeomFromWKB(ST_AsWKB(geom))) FROM types
+----
+POINT EMPTY
+POINT (0 0)
+LINESTRING EMPTY
+LINESTRING (0 0, 1 1)
+POLYGON EMPTY
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+MULTIPOINT EMPTY
+MULTIPOINT (0 0, 1 1)
+MULTILINESTRING EMPTY
+MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))
+MULTIPOLYGON EMPTY
+MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))
+GEOMETRYCOLLECTION EMPTY
+GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))
+
+# Convert to BLOB and back
+query I
+SELECT ST_AsText(ST_GeomFromWKB(ST_AsWKB(geom)::BLOB)) FROM types
+----
+POINT EMPTY
+POINT (0 0)
+LINESTRING EMPTY
+LINESTRING (0 0, 1 1)
+POLYGON EMPTY
+POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
+MULTIPOINT EMPTY
+MULTIPOINT (0 0, 1 1)
+MULTILINESTRING EMPTY
+MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))
+MULTIPOLYGON EMPTY
+MULTIPOLYGON (((0 0, 1 0, 1 1, 0 1, 0 0)), ((2 2, 3 2, 3 3, 2 3, 2 2)))
+GEOMETRYCOLLECTION EMPTY
+GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 0, 1 1))


### PR DESCRIPTION
Previously it was impossible to convert a `BLOB` into `GEOMETRY`, but you can now do it with `ST_GeomFromWKB`, which also now throws if it fails to read the WKB.