### PR TITLE
Remove sqlite build dependency

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -43,7 +43,7 @@ jobs:
         apt-get install -y -qq software-properties-common
         add-apt-repository ppa:git-core/ppa
         apt-get update -y -qq
-        apt-get install -y -qq lsb-release sqlite3 ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client
+        apt-get install -y -qq lsb-release ninja-build make gcc-multilib g++-multilib libssl-dev wget openjdk-8-jdk zip maven unixodbc-dev libc6-dev-i386 lib32readline6-dev libssl-dev libcurl4-gnutls-dev libexpat1-dev gettext unzip build-essential checkinstall libffi-dev curl libz-dev openssh-client
     
     - name: Install Git 2.18.5
       if: ${{ matrix.arch == 'linux_amd64' || matrix.arch == 'linux_arm64' }}

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -36,10 +36,6 @@ jobs:
 
       - name: Install Ninja
         run: brew install ninja
-      
-      # We need this for bulding PROJ
-      - name: Install Sqlite3
-        run: brew install sqlite3
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -39,11 +39,6 @@ jobs:
         run: |
           choco install openssl -y --force
       
-      - name: Install SQLite
-        shell: bash
-        run: |
-          choco install sqlite -y --force
-      
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         with:

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -69,7 +69,7 @@ ExternalProject_Add(
 )
 endif()
 
-find_program(EXE_SQLITE3 sqlite3)
+
 # PROJ
 ExternalProject_Add(
     PROJ
@@ -89,7 +89,6 @@ ExternalProject_Add(
     -DBUILD_TESTING=OFF
     -DENABLE_CURL=OFF
     -DENABLE_TIFF=OFF
-    -DEXE_SQLITE3=${EXE_SQLITE3} # use the sqlite3 executable from the system
 )
 
 # EXPAT


### PR DESCRIPTION
We now bundle a patched PROJ lib which does not try to produce the projection sqlite db during build time. We can do this since we include the db into the binary itself already and read it through a modified sqlite3 virtual filesystem. We also build our own local sqlite binary as part of building our dependencies, which PROJ finds, but doesn't use.