### PR TITLE
Add geometry->blob cast

### DIFF
--- a/spatial/src/spatial/core/functions/cast/wkb_cast.cpp
+++ b/spatial/src/spatial/core/functions/cast/wkb_cast.cpp
@@ -61,6 +61,9 @@ void CoreCastFunctions::RegisterWKBCasts(ClientContext &context) {
 
 	// WKB -> BLOB is implicitly castable
 	casts.RegisterCastFunction(GeoTypes::WKB_BLOB(), LogicalType::BLOB, DefaultCasts::ReinterpretCast, 1);
+
+	// Geometry -> BLOB is implicitly castable
+	casts.RegisterCastFunction(GeoTypes::GEOMETRY(), LogicalType::BLOB, DefaultCasts::ReinterpretCast, 1);
 }
 
 } // namespace core


### PR DESCRIPTION
Closes #70 

DuckDBs sqlite3 wrapper used in the shell detects that the GEOMETRY physical type is blob, but since we couldn't cast geometry to blob the value conversion returned a nullptr which segfaulted when printing json/lines