### PR TITLE
Add member type and role fields to relation in native osm pbf reader.

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -67,7 +67,6 @@ jobs:
           # Disable building shell. Since it includes sqlite3 which we statically link to as well it causes a conflict
           # and the build fails. Fixing this is a bit more involved so for now we just disable building the shell on windows.
           BUILD_SHELL: 0
-          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
         
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Reading from `osm.pbf` files will now include two new list fields that were previously missing:
- ref_roles (`VARCHAR[]`): The osm "role" for each relation reference, NULL if the reference has no role.
- ref_types(`OSM_REF_TYPE[]`): The osm entity type for each relation reference, the `OSM_REF_TYPE` enum contains one of `node`, `way` or `relation`.

