### PR TITLE
Apply patch and update duck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,14 @@ endif
 CLIENT_FLAGS :=
 
 # These flags will make DuckDB build the extension
-EXTENSION_FLAGS=-DENABLE_SANITIZER=OFF -DDUCKDB_EXTENSION_NAMES="spatial" -DDUCKDB_EXTENSION_SPATIAL_PATH="$(PROJ_DIR)" -DDUCKDB_EXTENSION_SPATIAL_SHOULD_LINK="TRUE" -DDUCKDB_EXTENSION_SPATIAL_INCLUDE_PATH="$(PROJ_DIR)spatial/include"
+EXTENSION_FLAGS=\
+-DENABLE_SANITIZER=OFF \
+-DDUCKDB_EXTENSION_NAMES="spatial" \
+-DDUCKDB_EXTENSION_SPATIAL_PATH="$(PROJ_DIR)" \
+-DDUCKDB_EXTENSION_SPATIAL_SHOULD_LINK=1 \
+-DDUCKDB_EXTENSION_SPATIAL_LOAD_TESTS=1 \
+-DDUCKDB_EXTENSION_SPATIAL_TEST_PATH="$(PROJ_DIR)test" \
+-DDUCKDB_EXTENSION_SPATIAL_INCLUDE_PATH="$(PROJ_DIR)spatial/include" \
 
 pull:
 	git submodule init
@@ -84,13 +91,13 @@ release_python: release
 test: test_release
 
 test_release: release
-	./build/release/test/unittest --test-dir . "test/sql/*"
+	./build/release/test/unittest "$(PROJ_DIR)test/*"
 
 test_debug: debug
-	./build/debug/test/unittest --test-dir . "test/sql/*"
+	./build/debug/test/unittest "$(PROJ_DIR)test/*"
 
 test_debug_lldb: debug
-	lldb ./build/debug/test/unittest -- --test-dir . "test/sql/*"
+	lldb ./build/debug/test/unittest "$(PROJ_DIR)test/*"
 
 # Client tests
 test_js: test_debug_js

--- a/spatial/src/spatial/gdal/functions/st_write.cpp
+++ b/spatial/src/spatial/gdal/functions/st_write.cpp
@@ -104,7 +104,8 @@ static unique_ptr<FunctionData> Bind(ClientContext &context, CopyInfo &info, vec
 
 	if (bind_data->layer_name.empty()) {
 		// Default to the base name of the file
-		bind_data->layer_name = FileSystem::ExtractBaseName(bind_data->file_path);
+		auto& fs = FileSystem::GetFileSystem(context);
+		bind_data->layer_name = fs.ExtractBaseName(bind_data->file_path);
 	}
 
 	return std::move(bind_data);


### PR DESCRIPTION
Applies outstanding patch fromDuckDB repo, switches to extension test loading instead of using the --test-dir. What this fixes is that the unittest binary that is produced in the build can now actually be run without the --test-dir param to run both standard DuckDB tests and the spatial tests