### PR TITLE
Allow passing `HEADERS=[AUTO/FORCE/DISABLE]` st_read() to control xlsx behavior.

### DIFF
--- a/spatial/src/spatial/gdal/functions/st_read.cpp
+++ b/spatial/src/spatial/gdal/functions/st_read.cpp
@@ -110,14 +110,26 @@ struct GdalScanLocalState : ArrowScanLocalState {
 
 struct GdalScanGlobalState : ArrowScanGlobalState {};
 
-struct ScopeGuard {
-	std::function<void()> f;
-	ScopeGuard(std::function<void()> f) : f(f) {
+
+struct ScopedOption {
+	string option;
+	string original_value;
+
+	ScopedOption(string option_p, const char* default_value) : option(option_p) {
+		// Save current value
+		original_value = CPLGetConfigOption(option.c_str(), default_value);
 	}
-	~ScopeGuard() {
-		f();
+
+	void Set(const char* new_value) {
+		CPLSetThreadLocalConfigOption(option.c_str(), new_value);
+	}
+
+	~ScopedOption() {
+		// Reset
+		CPLSetThreadLocalConfigOption(option.c_str(), original_value.c_str());
 	}
 };
+
 
 unique_ptr<FunctionData> GdalTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                  vector<LogicalType> &return_types, vector<string> &names) {
@@ -163,20 +175,29 @@ unique_ptr<FunctionData> GdalTableFunction::Bind(ClientContext &context, TableFu
 
 	// HACK: check for XLSX_HEADERS open option
 	// TODO: Remove this once GDAL 3.8 is released
-	auto xlsx_default = string(CPLGetConfigOption("OGR_XLSX_HEADERS", "AUTO"));
+	ScopedOption xlsx_headers("OGR_XLSX_HEADERS", "AUTO");
+	ScopedOption xlsx_field_types("OGR_XLSX_FIELD_TYPES", "AUTO");
 	for (auto &option : gdal_open_options) {
 		if (option == nullptr) {
 			break;
 		}
-		if (strcmp(option, "HEADERS=FORCE") == 0) {
-			CPLSetThreadLocalConfigOption("OGR_XLSX_HEADERS", "FORCE");
-
+		else if (strcmp(option, "HEADERS=FORCE") == 0) {
+			xlsx_headers.Set("FORCE");
 		}
-		if (strcmp(option, "HEADERS=DISABLE") == 0) {
-			CPLSetThreadLocalConfigOption("OGR_XLSX_HEADERS", "DISABLE");
+		else if (strcmp(option, "HEADERS=DISABLE") == 0) {
+			xlsx_headers.Set("DISABLE");
+		}
+		else if (strcmp(option, "HEADERS=AUTO") == 0) {
+			xlsx_headers.Set("AUTO");
+		}
+		else if (strcmp(option, "FIELD_TYPES=STRING") == 0) {
+			xlsx_field_types.Set("STRING");
+		}
+		else if (strcmp(option, "FIELD_TYPES=AUTO") == 0) {
+			xlsx_field_types.Set("AUTO");
 		}
 	}
-
+	
 	// Now we can open the dataset
 	auto file_name = input.inputs[0].GetValue<string>();
 	auto dataset =
@@ -184,11 +205,6 @@ unique_ptr<FunctionData> GdalTableFunction::Bind(ClientContext &context, TableFu
 	                                           gdal_allowed_drivers.empty() ? nullptr : gdal_allowed_drivers.data(),
 	                                           gdal_open_options.empty() ? nullptr : gdal_open_options.data(),
 	                                           gdal_sibling_files.empty() ? nullptr : gdal_sibling_files.data()));
-
-	// Reset upon exit
-	ScopeGuard _guard([&] {
-		CPLSetThreadLocalConfigOption("OGR_XLSX_HEADERS", xlsx_default.c_str());
-	});
 
 
 	if (dataset == nullptr) {

--- a/spatial/src/spatial/gdal/module.cpp
+++ b/spatial/src/spatial/gdal/module.cpp
@@ -14,7 +14,6 @@ void GdalModule::Register(ClientContext &context) {
 	// Load GDAL
 	OGRRegisterAll();
 
-
 	// Register functions
 	GdalTableFunction::Register(context);
 	GdalDriversTableFunction::Register(context);

--- a/spatial/src/spatial/gdal/module.cpp
+++ b/spatial/src/spatial/gdal/module.cpp
@@ -4,8 +4,6 @@
 #include "spatial/common.hpp"
 
 #include "ogrsf_frmts.h"
-#include "duckdb/main/client_data.hpp"
-#include "duckdb/main/client_config.hpp"
 
 namespace spatial {
 
@@ -16,32 +14,6 @@ void GdalModule::Register(ClientContext &context) {
 	// Load GDAL
 	OGRRegisterAll();
 
-
-	// Config options
-	auto &config = DBConfig::GetConfig(*context.db);
-	
-	// TODO: Remove this once GDAL 3.8 is released
-	CPLSetConfigOption("OGR_XLSX_HEADERS", "AUTO");
-	config.AddExtensionOption(
-		"OGR_XLSX_HEADERS", 
-		"Whether or not to read headers in xlsx through st_read. One of [FORCE/DISABLE/AUTO]", 
-		LogicalType::VARCHAR,
-		Value("AUTO"),
-		[](ClientContext &context, SetScope scope, Value &val) {
-			auto str = StringValue::Get(val);
-			if(str == "FORCE") {
-				CPLSetConfigOption("OGR_XLSX_HEADERS", "FORCE");
-			}
-			else if(str == "DISABLE") {
-				CPLSetConfigOption("OGR_XLSX_HEADERS", "DISABLE");
-			}
-			else if(str == "AUTO") {
-				CPLSetConfigOption("OGR_XLSX_HEADERS", "AUTO");
-			}
-			else {
-				throw InvalidInputException(StringUtil::Format("Invalid value '%s' for OGR_XLSX_HEADERS, must be one of [FORCE/DISABLE/AUTO]", str));
-			}
-		});
 
 	// Register functions
 	GdalTableFunction::Register(context);

--- a/spatial/src/spatial/gdal/module.cpp
+++ b/spatial/src/spatial/gdal/module.cpp
@@ -4,6 +4,8 @@
 #include "spatial/common.hpp"
 
 #include "ogrsf_frmts.h"
+#include "duckdb/main/client_data.hpp"
+#include "duckdb/main/client_config.hpp"
 
 namespace spatial {
 
@@ -13,6 +15,33 @@ void GdalModule::Register(ClientContext &context) {
 
 	// Load GDAL
 	OGRRegisterAll();
+
+
+	// Config options
+	auto &config = DBConfig::GetConfig(*context.db);
+	
+	// TODO: Remove this once GDAL 3.8 is released
+	CPLSetConfigOption("OGR_XLSX_HEADERS", "AUTO");
+	config.AddExtensionOption(
+		"OGR_XLSX_HEADERS", 
+		"Whether or not to read headers in xlsx through st_read. One of [FORCE/DISABLE/AUTO]", 
+		LogicalType::VARCHAR,
+		Value("AUTO"),
+		[](ClientContext &context, SetScope scope, Value &val) {
+			auto str = StringValue::Get(val);
+			if(str == "FORCE") {
+				CPLSetConfigOption("OGR_XLSX_HEADERS", "FORCE");
+			}
+			else if(str == "DISABLE") {
+				CPLSetConfigOption("OGR_XLSX_HEADERS", "DISABLE");
+			}
+			else if(str == "AUTO") {
+				CPLSetConfigOption("OGR_XLSX_HEADERS", "AUTO");
+			}
+			else {
+				throw InvalidInputException(StringUtil::Format("Invalid value '%s' for OGR_XLSX_HEADERS, must be one of [FORCE/DISABLE/AUTO]", str));
+			}
+		});
 
 	// Register functions
 	GdalTableFunction::Register(context);


### PR DESCRIPTION
This PR makes it possible to pass a `HEADERS=[AUTO/FORCE/DISABLE]` option to `st_read()` to control whether or not to read the first row as a header row or not when importing xlsx. We do this by setting a thread local config option programatically before opening the dataset, and resetting it after binding. Previously you would have to set this GDAL config option through an environment variable or an external configuration file, but now its possible to control it per-query and from within duckdb.

Example:
```sql
FROM ST_read('./output.xlsx', open_options = ['HEADERS=FORCE']);
```

Note that this workaround won't be necessary anymore since GDAL 3.8 (scheduled for November...?) as the XLSX options will be [possible to pass as open options](https://gdal.org/drivers/vector/xlsx.html) instead of configuration options natively.