### PR TITLE
Fix xlsx driver, st_write

### DIFF
--- a/spatial/src/spatial/gdal/functions/st_write.cpp
+++ b/spatial/src/spatial/gdal/functions/st_write.cpp
@@ -58,6 +58,8 @@ struct GlobalState : public GlobalFunctionData {
 static unique_ptr<FunctionData> Bind(ClientContext &context, CopyInfo &info, vector<string> &names,
                                      vector<LogicalType> &sql_types) {
 
+	GdalFileHandler::SetLocalClientContext(context);
+
 	auto bind_data = make_uniq<BindData>(info.file_path, sql_types, names);
 
 	// check all the options in the copy info
@@ -366,7 +368,6 @@ static void SetOgrFieldFromValue(OGRFeature *feature, int field_idx, const Logic
 
 static void Sink(ExecutionContext &context, FunctionData &bdata, GlobalFunctionData &gstate, LocalFunctionData &lstate,
                  DataChunk &input) {
-
 	auto &bind_data = (BindData &)bdata;
 	auto &global_state = (GlobalState &)gstate;
 	auto &local_state = (LocalState &)lstate;
@@ -408,6 +409,7 @@ static void Sink(ExecutionContext &context, FunctionData &bdata, GlobalFunctionD
 // Finalize
 //===--------------------------------------------------------------------===//
 static void Finalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
+	GdalFileHandler::SetLocalClientContext(context);
 	auto &global_state = (GlobalState &)gstate;
 	global_state.dataset->FlushCache();
 }

--- a/test/sql/gdal/st_read_xlsx.test
+++ b/test/sql/gdal/st_read_xlsx.test
@@ -1,0 +1,10 @@
+require spatial
+
+# Test XLSX driver roundtrip
+statement ok
+COPY (SELECT 1337 as i, 'foobar' as f) TO '__TEST_DIR__/test.xlsx' WITH (FORMAT GDAL, DRIVER 'xlsx');
+
+query II
+SELECT i, f FROM st_read('__TEST_DIR__/test.xlsx');
+----
+1337	foobar


### PR DESCRIPTION
- XLSX requires the `stat` callback to be defined in the GDAL plugin filesystem, we now provide a stub for it.
- ST_Write didn't set the client context properly on finish which sometimes caused errors depending on which thread picked up the task.