### PR TITLE
Fix st_area when holes are presents

### DIFF
--- a/spatial/src/spatial/core/functions/scalar/st_area.cpp
+++ b/spatial/src/spatial/core/functions/scalar/st_area.cpp
@@ -41,6 +41,7 @@ static void PolygonAreaFunction(DataChunk &args, ExpressionState &state, Vector 
 			for (idx_t coord_idx = ring_offset; coord_idx < ring_offset + ring_length - 1; coord_idx++) {
 				sum += (x_data[coord_idx] * y_data[coord_idx + 1]) - (x_data[coord_idx + 1] * y_data[coord_idx]);
 			}
+			sum = std::abs(sum);
 			if (first) {
 				// Add outer ring
 				area = sum * 0.5;

--- a/spatial/src/spatial/core/geometry/geometry.cpp
+++ b/spatial/src/spatial/core/geometry/geometry.cpp
@@ -112,9 +112,9 @@ double Polygon::Area() const {
 	double area = 0;
 	for (uint32_t i = 0; i < num_rings; i++) {
 		if (i == 0) {
-			area += rings[i].SignedArea();
+			area += rings[i].Area();
 		} else {
-			area -= rings[i].SignedArea();
+			area -= rings[i].Area();
 		}
 	}
 	return std::abs(area);

--- a/test/sql/geometry/st_area.test
+++ b/test/sql/geometry/st_area.test
@@ -76,14 +76,36 @@ SELECT ST_Area(b) FROM (VALUES
 40
 100.0
 
-# Test ST_Area for POLYGON_2D
+# Test ST_Area for POLYGON_2D, also with holes
 query I
 SELECT ST_Area(p) FROM (VALUES
 	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')::POLYGON_2D),
-	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))')::POLYGON_2D) 
+	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))')::POLYGON_2D),
+	(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))')::POLYGON_2D),
+	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))')::POLYGON_2D),
+	(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))')::POLYGON_2D)
 ) as t(p);
 ----
 1
+0.64
+0.64
+0.64
+0.64
+
+# Test ST_Area for GEOMETRY, with holes
+query I
+SELECT ST_Area(p) FROM (VALUES
+	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))')),
+	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))')),
+	(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))')),
+	(ST_GeomFromText('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0), (0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))')),
+	(ST_GeomFromText('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0), (0.2 0.2, 0.2 0.8, 0.8 0.8, 0.8 0.2, 0.2 0.2))'))
+) as t(p);
+----
+1
+0.64
+0.64
+0.64
 0.64
 
 # Test ST_Area for POINT_2D


### PR DESCRIPTION
I am not sure whether this will have impact elsewhere, but I think it make sense both to uniform the convention between GEOMETRY and POLYGON_2D to be: `abs (area (first one) - sum (area (others) ) )` and have the result be invariant for clockwise or anticlockwise.

I had also bumped DuckDB version to v0.9.0 tag.

Fixes #134